### PR TITLE
Clean up code generation

### DIFF
--- a/http/proxy/Makefile
+++ b/http/proxy/Makefile
@@ -2,7 +2,7 @@
 
 default: wasi-http
 
-wasi-http: ; git clone https://github.com/WebAssembly/wasi-http; cd wasi-http; git checkout v0.2.0-rc-2023-11-10
+wasi-http: ; git clone https://github.com/WebAssembly/wasi-http; cd wasi-http; git checkout v0.2.0-rc-2023-11-10 ; cd ../ ; cp proxy.wit wasi-http/wit
 
 # Note that this doesn't quite work right there's a bug in wit-bindgen 0.4.0 that missing a C definition
 # it is fixed in later versions, but they don't understand this wit syntax *bleeding-edge*

--- a/http/proxy/proxy.wit
+++ b/http/proxy/proxy.wit
@@ -1,0 +1,35 @@
+package wasi:http@0.2.0-rc-2023-11-10;
+
+/// The `wasi:http/proxy` world captures a widely-implementable intersection of
+/// hosts that includes HTTP forward and reverse proxies. Components targeting
+/// this world may concurrently stream in and out any number of incoming and
+/// outgoing HTTP requests.
+world proxy {
+  /// HTTP proxies have access to time and randomness.
+  import wasi:clocks/wall-clock@0.2.0-rc-2023-11-10;
+  import wasi:clocks/monotonic-clock@0.2.0-rc-2023-11-10;
+  import wasi:random/random@0.2.0-rc-2023-11-10;
+
+  /// Proxies have standard output and error streams which are expected to
+  /// terminate in a developer-facing console provided by the host.
+  import wasi:cli/stdout@0.2.0-rc-2023-11-10;
+  import wasi:cli/stderr@0.2.0-rc-2023-11-10;
+
+  /// TODO: this is a temporary workaround until component tooling is able to
+  /// gracefully handle the absence of stdin. Hosts must return an eof stream
+  /// for this import, which is what wasi-libc + tooling will do automatically
+  /// when this import is properly removed.
+  import wasi:cli/stdin@0.2.0-rc-2023-11-10;
+
+  /// This is the default handler to use when user code simply wants to make an
+  /// HTTP request (e.g., via `fetch()`).
+  import outgoing-handler;
+
+  /// The host delivers incoming HTTP requests to a component by calling the
+  /// `handle` function of this exported interface. A host may arbitrarily reuse
+  /// or not reuse component instance when delivering incoming HTTP requests and
+  /// thus a component must be able to handle 0..N calls to `handle`.
+  export incoming-handler;
+
+  export wasi:cli/run@0.2.0-rc-2023-11-10;
+}


### PR DESCRIPTION
Fixes #9 

This isn't the optimal fix. Should probably split out the CLI client stuff from the proxy package.